### PR TITLE
test: implement comprehensive provider tests for Phase 2.3

### DIFF
--- a/tests/provider/filtering.test.ts
+++ b/tests/provider/filtering.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Property source filtering tests for ConfigServerProvider.
+ *
+ * Tests the property source filtering logic used during resource creation.
+ * Focuses on filter matching, case sensitivity, and edge cases.
+ */
+
+import { ConfigServerProvider } from '../../src/provider';
+import { ConfigServerClient } from '../../src/client';
+import type { PropertySource } from '../../src/types';
+import {
+  multiSourceResponse,
+  vaultOnlyResponse,
+  gitOnlyResponse,
+} from '../fixtures/config-server-responses';
+
+// Mock the client module
+jest.mock('../../src/client');
+
+describe('ConfigServerProvider - Filtering', () => {
+  let provider: ConfigServerProvider;
+  let mockFetchConfigWithRetry: jest.Mock;
+
+  beforeEach(() => {
+    provider = new ConfigServerProvider();
+    mockFetchConfigWithRetry = jest.fn();
+
+    (ConfigServerClient as jest.Mock).mockImplementation(() => ({
+      fetchConfigWithRetry: mockFetchConfigWithRetry,
+    }));
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Property Source Filtering', () => {
+    it('should filter by single property source name', async () => {
+      mockFetchConfigWithRetry.mockResolvedValue(multiSourceResponse);
+
+      const inputs = {
+        configServerUrl: 'http://localhost:8888',
+        application: 'multi-app',
+        profile: 'staging',
+        propertySources: ['vault'],
+      };
+
+      const result = await provider.create(inputs);
+
+      expect(result.outs.config.propertySources).toHaveLength(1);
+      expect(result.outs.config.propertySources[0].name).toContain('vault');
+    });
+
+    it('should filter by multiple property source names', async () => {
+      mockFetchConfigWithRetry.mockResolvedValue(multiSourceResponse);
+
+      const inputs = {
+        configServerUrl: 'http://localhost:8888',
+        application: 'multi-app',
+        profile: 'staging',
+        propertySources: ['vault', 'git'],
+      };
+
+      const result = await provider.create(inputs);
+
+      expect(result.outs.config.propertySources.length).toBeGreaterThanOrEqual(2);
+      const names = result.outs.config.propertySources.map((ps: PropertySource) => ps.name);
+      expect(names.some((name: string) => name.includes('vault'))).toBe(true);
+      expect(names.some((name: string) => name.includes('git'))).toBe(true);
+    });
+
+    it('should return empty when no matching property sources', async () => {
+      mockFetchConfigWithRetry.mockResolvedValue(vaultOnlyResponse);
+
+      const inputs = {
+        configServerUrl: 'http://localhost:8888',
+        application: 'vault-app',
+        profile: 'prod',
+        propertySources: ['nonexistent'],
+      };
+
+      const result = await provider.create(inputs);
+
+      expect(result.outs.config.propertySources).toHaveLength(0);
+      expect(result.outs.properties).toEqual({});
+    });
+
+    it('should include all sources when propertySourcesToInclude is empty array', async () => {
+      mockFetchConfigWithRetry.mockResolvedValue(multiSourceResponse);
+
+      const inputs = {
+        configServerUrl: 'http://localhost:8888',
+        application: 'multi-app',
+        profile: 'staging',
+        propertySources: [],
+      };
+
+      const result = await provider.create(inputs);
+
+      expect(result.outs.config.propertySources).toHaveLength(
+        multiSourceResponse.propertySources.length
+      );
+    });
+
+    it('should include all sources when propertySourcesToInclude is undefined', async () => {
+      mockFetchConfigWithRetry.mockResolvedValue(multiSourceResponse);
+
+      const inputs = {
+        configServerUrl: 'http://localhost:8888',
+        application: 'multi-app',
+        profile: 'staging',
+        // propertySources omitted (undefined)
+      };
+
+      const result = await provider.create(inputs);
+
+      expect(result.outs.config.propertySources).toHaveLength(
+        multiSourceResponse.propertySources.length
+      );
+    });
+
+    it('should use case-insensitive property source matching', async () => {
+      mockFetchConfigWithRetry.mockResolvedValue(vaultOnlyResponse);
+
+      const inputs = {
+        configServerUrl: 'http://localhost:8888',
+        application: 'vault-app',
+        profile: 'prod',
+        propertySources: ['VAULT'],
+      };
+
+      const result = await provider.create(inputs);
+
+      expect(result.outs.config.propertySources).toHaveLength(1);
+      expect(result.outs.config.propertySources[0].name.toLowerCase()).toContain('vault');
+    });
+
+    it('should not match property sources with partial name match only', async () => {
+      mockFetchConfigWithRetry.mockResolvedValue(gitOnlyResponse);
+
+      const inputs = {
+        configServerUrl: 'http://localhost:8888',
+        application: 'git-app',
+        profile: 'dev',
+        propertySources: ['vault'], // gitOnlyResponse has no vault sources
+      };
+
+      const result = await provider.create(inputs);
+
+      expect(result.outs.config.propertySources).toHaveLength(0);
+    });
+
+    it('should handle multiple sources with same name prefix', async () => {
+      // Create a response with multiple vault sources
+      const multiVaultResponse = {
+        name: 'multi-vault-app',
+        profiles: ['prod'],
+        label: null,
+        version: null,
+        state: null,
+        propertySources: [
+          {
+            name: 'vault:secret/app/common',
+            source: { 'common.property': 'value1' },
+          },
+          {
+            name: 'vault:secret/app/prod',
+            source: { 'prod.property': 'value2' },
+          },
+          {
+            name: 'file:./config/application.yml',
+            source: { 'file.property': 'value3' },
+          },
+        ],
+      };
+
+      mockFetchConfigWithRetry.mockResolvedValue(multiVaultResponse);
+
+      const inputs = {
+        configServerUrl: 'http://localhost:8888',
+        application: 'multi-vault-app',
+        profile: 'prod',
+        propertySources: ['vault'],
+      };
+
+      const result = await provider.create(inputs);
+
+      expect(result.outs.config.propertySources).toHaveLength(2);
+      expect(result.outs.config.propertySources[0].name).toContain('vault');
+      expect(result.outs.config.propertySources[1].name).toContain('vault');
+    });
+
+    it('should preserve order of property sources after filtering', async () => {
+      mockFetchConfigWithRetry.mockResolvedValue(multiSourceResponse);
+
+      const inputs = {
+        configServerUrl: 'http://localhost:8888',
+        application: 'multi-app',
+        profile: 'staging',
+        propertySources: ['git', 'vault'],
+      };
+
+      const result = await provider.create(inputs);
+
+      // Original order in multiSourceResponse: file, git, vault
+      // After filtering for git and vault, git should come before vault
+      const names = result.outs.config.propertySources.map((ps: PropertySource) => ps.name);
+      const gitIndex: number = names.findIndex((name: string) => name.includes('git'));
+      const vaultIndex: number = names.findIndex((name: string) => name.includes('vault'));
+
+      expect(gitIndex).toBeGreaterThanOrEqual(0);
+      expect(vaultIndex).toBeGreaterThanOrEqual(0);
+      expect(gitIndex).toBeLessThan(vaultIndex);
+    });
+
+    it('should filter vault-only response correctly', async () => {
+      mockFetchConfigWithRetry.mockResolvedValue(vaultOnlyResponse);
+
+      const inputs = {
+        configServerUrl: 'http://localhost:8888',
+        application: 'vault-app',
+        profile: 'prod',
+        propertySources: ['vault'],
+      };
+
+      const result = await provider.create(inputs);
+
+      expect(result.outs.config.propertySources).toHaveLength(1);
+      expect(result.outs.config.propertySources[0].name).toContain('vault');
+      expect(result.outs.properties).toMatchObject({
+        'database.host': 'prod-db.example.com',
+        'database.port': '5432',
+      });
+    });
+  });
+});

--- a/tests/provider/lifecycle.test.ts
+++ b/tests/provider/lifecycle.test.ts
@@ -1,0 +1,329 @@
+/**
+ * Lifecycle tests for ConfigServerProvider.
+ *
+ * Tests Pulumi resource lifecycle methods: create, diff, update.
+ * Focuses on state management, output structure, and error handling.
+ */
+
+import { ConfigServerProvider } from '../../src/provider';
+import { ConfigServerClient } from '../../src/client';
+import { createMockConfigResponse } from '../helpers';
+import {
+  smallConfigResponse,
+  multiSourceResponse,
+  emptyResponse,
+} from '../fixtures/config-server-responses';
+
+// Mock the client module
+jest.mock('../../src/client');
+
+describe('ConfigServerProvider - Lifecycle', () => {
+  let provider: ConfigServerProvider;
+  let mockFetchConfigWithRetry: jest.Mock;
+
+  beforeEach(() => {
+    // Reset the provider instance
+    provider = new ConfigServerProvider();
+
+    // Create mock for fetchConfigWithRetry
+    mockFetchConfigWithRetry = jest.fn();
+
+    // Mock ConfigServerClient constructor
+    (ConfigServerClient as jest.Mock).mockImplementation(() => ({
+      fetchConfigWithRetry: mockFetchConfigWithRetry,
+    }));
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('create()', () => {
+    it('should successfully create resource with valid inputs', async () => {
+      mockFetchConfigWithRetry.mockResolvedValue(smallConfigResponse);
+
+      const inputs = {
+        configServerUrl: 'http://localhost:8888',
+        application: 'test-app',
+        profile: 'dev',
+      };
+
+      const result = await provider.create(inputs);
+
+      expect(result.id).toBe('test-app-dev');
+      expect(result.outs).toBeDefined();
+      expect(mockFetchConfigWithRetry).toHaveBeenCalledWith('test-app', 'dev', undefined, {
+        maxRetries: 3,
+        retryDelay: 1000,
+        backoffMultiplier: 2,
+      });
+    });
+
+    it('should return correct output structure with all fields', async () => {
+      mockFetchConfigWithRetry.mockResolvedValue(smallConfigResponse);
+
+      const inputs = {
+        configServerUrl: 'http://localhost:8888',
+        application: 'my-app',
+        profile: 'prod',
+        label: 'v1.0.0',
+        username: 'user',
+        password: 'pass',
+      };
+
+      const result = await provider.create(inputs);
+
+      expect(result.outs).toMatchObject({
+        configServerUrl: 'http://localhost:8888',
+        application: 'my-app',
+        profile: 'prod',
+        label: 'v1.0.0',
+        username: 'user',
+        password: 'pass',
+        config: expect.any(Object),
+        properties: expect.any(Object),
+      });
+    });
+
+    it('should create with property source filtering', async () => {
+      mockFetchConfigWithRetry.mockResolvedValue(multiSourceResponse);
+
+      const inputs = {
+        configServerUrl: 'http://localhost:8888',
+        application: 'test-app',
+        profile: 'dev',
+        propertySources: ['vault'],
+      };
+
+      const result = await provider.create(inputs);
+
+      expect(result.outs.config.propertySources).toHaveLength(1);
+      expect(result.outs.config.propertySources[0].name).toContain('vault');
+    });
+
+    it('should create with no property sources (empty config)', async () => {
+      mockFetchConfigWithRetry.mockResolvedValue(emptyResponse);
+
+      const inputs = {
+        configServerUrl: 'http://localhost:8888',
+        application: 'empty-app',
+        profile: 'dev',
+      };
+
+      const result = await provider.create(inputs);
+
+      expect(result.outs.config.propertySources).toHaveLength(0);
+      expect(result.outs.properties).toEqual({});
+    });
+
+    it('should propagate error from client', async () => {
+      const error = new Error('Config server unreachable');
+      mockFetchConfigWithRetry.mockRejectedValue(error);
+
+      const inputs = {
+        configServerUrl: 'http://localhost:8888',
+        application: 'test-app',
+        profile: 'dev',
+      };
+
+      await expect(provider.create(inputs)).rejects.toThrow('Config server unreachable');
+    });
+
+    it('should create with all optional inputs', async () => {
+      mockFetchConfigWithRetry.mockResolvedValue(smallConfigResponse);
+
+      const inputs = {
+        configServerUrl: 'http://localhost:8888',
+        application: 'test-app',
+        profile: 'dev',
+        label: 'main',
+        username: 'admin',
+        password: 'secret',
+        propertySources: ['vault'],
+        timeout: 15000,
+        debug: true,
+        autoDetectSecrets: true,
+        enforceHttps: false,
+      };
+
+      const result = await provider.create(inputs);
+
+      expect(result.outs.label).toBe('main');
+      expect(result.outs.username).toBe('admin');
+      expect(result.outs.password).toBe('secret');
+      expect(result.outs.timeout).toBe(15000);
+      expect(result.outs.debug).toBe(true);
+      expect(result.outs.autoDetectSecrets).toBe(true);
+      expect(result.outs.enforceHttps).toBe(false);
+    });
+
+    it('should persist state correctly in outputs', async () => {
+      mockFetchConfigWithRetry.mockResolvedValue(smallConfigResponse);
+
+      const inputs = {
+        configServerUrl: 'http://localhost:8888',
+        application: 'test-app',
+        profile: 'dev',
+      };
+
+      const result = await provider.create(inputs);
+
+      // Verify outputs match fetched config
+      expect(result.outs.config.name).toBe(smallConfigResponse.name);
+      expect(result.outs.config.profiles).toEqual(smallConfigResponse.profiles);
+      expect(result.outs.config.propertySources).toEqual(smallConfigResponse.propertySources);
+      expect(result.outs.properties).toEqual(smallConfigResponse.propertySources[0].source);
+    });
+  });
+
+  describe('diff()', () => {
+    const oldOutputs = {
+      configServerUrl: 'http://localhost:8888',
+      application: 'test-app',
+      profile: 'dev',
+      label: 'main',
+      username: 'user',
+      password: 'pass',
+      propertySources: ['vault'],
+      timeout: 10000,
+      debug: false,
+      autoDetectSecrets: true,
+      enforceHttps: false,
+      config: smallConfigResponse,
+      properties: {},
+    };
+
+    it('should detect application name change', async () => {
+      const newInputs = { ...oldOutputs, application: 'new-app' };
+      const result = await provider.diff('test-app-dev', oldOutputs, newInputs);
+
+      expect(result.changes).toBe(true);
+    });
+
+    it('should detect profile change', async () => {
+      const newInputs = { ...oldOutputs, profile: 'prod' };
+      const result = await provider.diff('test-app-dev', oldOutputs, newInputs);
+
+      expect(result.changes).toBe(true);
+    });
+
+    it('should detect label change', async () => {
+      const newInputs = { ...oldOutputs, label: 'v2.0.0' };
+      const result = await provider.diff('test-app-dev', oldOutputs, newInputs);
+
+      expect(result.changes).toBe(true);
+    });
+
+    it('should detect URL change', async () => {
+      const newInputs = { ...oldOutputs, configServerUrl: 'http://newserver:8888' };
+      const result = await provider.diff('test-app-dev', oldOutputs, newInputs);
+
+      expect(result.changes).toBe(true);
+    });
+
+    it('should detect auth change (username/password)', async () => {
+      const newInputs = { ...oldOutputs, username: 'newuser', password: 'newpass' };
+      const result = await provider.diff('test-app-dev', oldOutputs, newInputs);
+
+      expect(result.changes).toBe(true);
+    });
+
+    it('should return no changes when inputs identical', async () => {
+      const newInputs = { ...oldOutputs };
+      const result = await provider.diff('test-app-dev', oldOutputs, newInputs);
+
+      expect(result.changes).toBe(false);
+    });
+
+    it('should handle diff with refresh flag behavior', async () => {
+      const newInputs = { ...oldOutputs };
+      const result = await provider.diff('test-app-dev', oldOutputs, newInputs);
+
+      // No changes should be detected, replaces should be empty
+      expect(result.changes).toBe(false);
+      expect(result.replaces).toEqual([]);
+    });
+  });
+
+  describe('update()', () => {
+    it('should re-fetch configuration on update', async () => {
+      const updatedResponse = createMockConfigResponse({
+        name: 'updated-app',
+        profiles: ['prod'],
+        sources: [
+          {
+            name: 'vault:updated',
+            source: { 'new.property': 'new-value' },
+          },
+        ],
+      });
+
+      mockFetchConfigWithRetry.mockResolvedValue(updatedResponse);
+
+      const oldOutputs = {
+        configServerUrl: 'http://localhost:8888',
+        application: 'test-app',
+        profile: 'dev',
+        config: smallConfigResponse,
+        properties: {},
+      };
+
+      const newInputs = {
+        configServerUrl: 'http://localhost:8888',
+        application: 'test-app',
+        profile: 'prod',
+      };
+
+      const result = await provider.update('test-app-dev', oldOutputs, newInputs);
+
+      expect(mockFetchConfigWithRetry).toHaveBeenCalled();
+      expect(result.outs.config.name).toBe('updated-app');
+    });
+
+    it('should return new outputs after update', async () => {
+      mockFetchConfigWithRetry.mockResolvedValue(smallConfigResponse);
+
+      const oldOutputs = {
+        configServerUrl: 'http://localhost:8888',
+        application: 'test-app',
+        profile: 'dev',
+        config: smallConfigResponse,
+        properties: {},
+      };
+
+      const newInputs = {
+        configServerUrl: 'http://localhost:8888',
+        application: 'test-app',
+        profile: 'prod',
+      };
+
+      const result = await provider.update('test-app-dev', oldOutputs, newInputs);
+
+      expect(result.outs).toBeDefined();
+      expect(result.outs.profile).toBe('prod');
+    });
+
+    it('should handle update error propagation', async () => {
+      const error = new Error('Update failed - server unreachable');
+      mockFetchConfigWithRetry.mockRejectedValue(error);
+
+      const oldOutputs = {
+        configServerUrl: 'http://localhost:8888',
+        application: 'test-app',
+        profile: 'dev',
+        config: smallConfigResponse,
+        properties: {},
+      };
+
+      const newInputs = {
+        configServerUrl: 'http://localhost:8888',
+        application: 'test-app',
+        profile: 'prod',
+      };
+
+      await expect(provider.update('test-app-dev', oldOutputs, newInputs)).rejects.toThrow(
+        'Update failed - server unreachable'
+      );
+    });
+  });
+});

--- a/tests/provider/validation.test.ts
+++ b/tests/provider/validation.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Input validation and security tests for ConfigServerProvider.
+ *
+ * Tests input validation, HTTPS warnings, and security enforcement.
+ * Focuses on required fields, URL validation, and HTTPS policy.
+ */
+
+import * as pulumi from '@pulumi/pulumi';
+import { ConfigServerProvider } from '../../src/provider';
+import { ConfigServerClient } from '../../src/client';
+import { smallConfigResponse } from '../fixtures/config-server-responses';
+
+// Mock the client module
+jest.mock('../../src/client');
+
+describe('ConfigServerProvider - Validation', () => {
+  let provider: ConfigServerProvider;
+  let mockFetchConfigWithRetry: jest.Mock;
+  let mockWarn: jest.SpyInstance;
+
+  beforeEach(() => {
+    provider = new ConfigServerProvider();
+    mockFetchConfigWithRetry = jest.fn();
+
+    (ConfigServerClient as jest.Mock).mockImplementation(() => ({
+      fetchConfigWithRetry: mockFetchConfigWithRetry,
+    }));
+
+    // Mock Pulumi logging
+    mockWarn = jest.spyOn(pulumi.log, 'warn').mockImplementation();
+
+    // Default success response
+    mockFetchConfigWithRetry.mockResolvedValue(smallConfigResponse);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    mockWarn.mockRestore();
+  });
+
+  describe('Input Validation', () => {
+    it('should validate required field: url', async () => {
+      const inputs = {
+        configServerUrl: '',
+        application: 'test-app',
+        profile: 'dev',
+      };
+
+      await expect(provider.create(inputs)).rejects.toThrow('configServerUrl is required');
+    });
+
+    it('should validate required field: application', async () => {
+      const inputs = {
+        configServerUrl: 'http://localhost:8888',
+        application: '',
+        profile: 'dev',
+      };
+
+      await expect(provider.create(inputs)).rejects.toThrow('application is required');
+    });
+
+    it('should validate required field: profile', async () => {
+      const inputs = {
+        configServerUrl: 'http://localhost:8888',
+        application: 'test-app',
+        profile: '',
+      };
+
+      await expect(provider.create(inputs)).rejects.toThrow('profile is required');
+    });
+
+    it('should handle optional fields (label, username, password)', async () => {
+      const inputs = {
+        configServerUrl: 'http://localhost:8888',
+        application: 'test-app',
+        profile: 'dev',
+        // label, username, password omitted
+      };
+
+      const result = await provider.create(inputs);
+
+      expect(result.outs.label).toBeUndefined();
+      expect(result.outs.username).toBeUndefined();
+      expect(result.outs.password).toBeUndefined();
+    });
+
+    it('should handle invalid URL format', async () => {
+      const inputs = {
+        configServerUrl: 'not-a-valid-url',
+        application: 'test-app',
+        profile: 'dev',
+      };
+
+      await expect(provider.create(inputs)).rejects.toThrow(
+        'Invalid configServerUrl: not-a-valid-url'
+      );
+    });
+
+    it('should handle empty string inputs for required fields', async () => {
+      const inputs = {
+        configServerUrl: '',
+        application: '',
+        profile: '',
+      };
+
+      await expect(provider.create(inputs)).rejects.toThrow('configServerUrl is required');
+    });
+  });
+
+  describe('HTTPS Validation', () => {
+    it('should trigger warning for HTTP URL (non-localhost)', async () => {
+      const inputs = {
+        configServerUrl: 'http://config-server.example.com:8888',
+        application: 'test-app',
+        profile: 'dev',
+      };
+
+      await provider.create(inputs);
+
+      expect(mockWarn).toHaveBeenCalledWith(expect.stringContaining('[Security Warning]'));
+      expect(mockWarn).toHaveBeenCalledWith(expect.stringContaining('HTTPS'));
+    });
+
+    it('should not trigger warning for HTTPS URL', async () => {
+      const inputs = {
+        configServerUrl: 'https://config-server.example.com:8888',
+        application: 'test-app',
+        profile: 'dev',
+      };
+
+      await provider.create(inputs);
+
+      expect(mockWarn).not.toHaveBeenCalled();
+    });
+
+    it('should not trigger warning for HTTP localhost', async () => {
+      const inputs = {
+        configServerUrl: 'http://localhost:8888',
+        application: 'test-app',
+        profile: 'dev',
+      };
+
+      await provider.create(inputs);
+
+      expect(mockWarn).not.toHaveBeenCalled();
+    });
+
+    it('should not trigger warning for HTTP 127.0.0.1', async () => {
+      const inputs = {
+        configServerUrl: 'http://127.0.0.1:8888',
+        application: 'test-app',
+        profile: 'dev',
+      };
+
+      await provider.create(inputs);
+
+      expect(mockWarn).not.toHaveBeenCalled();
+    });
+
+    it('should throw error when enforceHttps: true with HTTP URL', async () => {
+      const inputs = {
+        configServerUrl: 'http://config-server.example.com:8888',
+        application: 'test-app',
+        profile: 'dev',
+        enforceHttps: true,
+      };
+
+      await expect(provider.create(inputs)).rejects.toThrow('HTTPS is strongly recommended');
+      await expect(provider.create(inputs)).rejects.toThrow(
+        'Set enforceHttps: false to allow HTTP'
+      );
+    });
+
+    it('should allow HTTP URL when enforceHttps: false (but warn)', async () => {
+      const inputs = {
+        configServerUrl: 'http://config-server.example.com:8888',
+        application: 'test-app',
+        profile: 'dev',
+        enforceHttps: false,
+      };
+
+      const result = await provider.create(inputs);
+
+      expect(result).toBeDefined();
+      expect(mockWarn).toHaveBeenCalledWith(expect.stringContaining('[Security Warning]'));
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements comprehensive unit tests for the `ConfigServerProvider` dynamic provider class, covering all lifecycle methods, property source filtering, and input validation logic.

## Changes Made

### Test Files Created (3 files, 39 tests)

1. **tests/provider/lifecycle.test.ts** - 17 tests
   - ✅ Tests create() method with various input scenarios
   - ✅ Tests diff() method for change detection
   - ✅ Tests update() method for re-fetching configuration
   - ✅ Validates state persistence and output structure

2. **tests/provider/filtering.test.ts** - 10 tests
   - ✅ Tests property source filtering by single/multiple names
   - ✅ Tests case-insensitive matching
   - ✅ Tests empty results and filter edge cases
   - ✅ Validates source order preservation

3. **tests/provider/validation.test.ts** - 12 tests
   - ✅ Tests required field validation (url, application, profile)
   - ✅ Tests HTTPS validation and security warnings
   - ✅ Tests enforceHttps flag behavior
   - ✅ Tests localhost exception for HTTP URLs

## Test Coverage

```
File         | % Stmts | % Branch | % Funcs | % Lines
-------------|---------|----------|---------|--------
provider.ts  |     100 |      100 |     100 |     100
```

**All metrics at 100% - exceeds >80% requirement ✅**

## Quality Checks

- ✅ All 39 tests passing
- ✅ Lint checks pass (`npm run lint`)
- ✅ Code formatting verified
- ✅ Uses fixtures from Phase 2.1 (#17)
- ✅ Uses helpers from Phase 2.1 (#17)
- ✅ Follows patterns from Phase 2.2 (#18)
- ✅ Mocks Pulumi logging (no console spam)
- ✅ Mocks ConfigServerClient properly

## Dependencies

- ✅ #17 (Phase 2.1: Test Infrastructure Foundation) - Complete
- ✅ #18 (Phase 2.2: Client Tests) - Complete

## Testing Checklist

- [x] Run `npm test tests/provider/` - all tests pass
- [x] Run `npm run test:coverage` - provider.ts at 100% coverage
- [x] Verify all lifecycle methods covered
- [x] Verify HTTPS warnings work correctly
- [x] Run `npm run lint` - no lint errors

Fixes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)