### PR TITLE
test: increase coverage thresholds to 80% and fix nock compatibility issues

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -13,10 +13,10 @@ module.exports = {
   ],
   coverageThreshold: {
     global: {
-      branches: 0,
-      functions: 0,
-      lines: 0,
-      statements: 0,
+      branches: 80,
+      functions: 80,
+      lines: 80,
+      statements: 80,
     },
   },
   coverageDirectory: 'coverage',

--- a/tests/client/auth.test.ts
+++ b/tests/client/auth.test.ts
@@ -236,9 +236,9 @@ describe('ConfigServerClient - Authentication', () => {
       const client = new ConfigServerClient(urlWithCreds);
       const path = '/my-app/prod';
 
-      nock(urlWithCreds)
-        .get(path)
-        .replyWithError({ code: 'ECONNREFUSED', message: 'Connection refused' });
+      const networkError = new Error('Connection refused');
+      (networkError as NodeJS.ErrnoException).code = 'ECONNREFUSED';
+      nock(urlWithCreds).get(path).replyWithError(networkError);
 
       try {
         await client.fetchConfig('my-app', 'prod');

--- a/tests/client/retry.test.ts
+++ b/tests/client/retry.test.ts
@@ -101,9 +101,9 @@ describe('ConfigServerClient - Retry Logic', () => {
       const path = '/my-app/prod';
 
       // First call times out
-      nock(baseUrl)
-        .get(path)
-        .replyWithError({ code: 'ECONNABORTED', message: 'timeout of 1000ms exceeded' });
+      const timeoutError = new Error('timeout of 1000ms exceeded');
+      (timeoutError as NodeJS.ErrnoException).code = 'ECONNABORTED';
+      nock(baseUrl).get(path).replyWithError(timeoutError);
       // Second call succeeds
       mockNock(baseUrl, path, smallConfigResponse, 200);
 

--- a/tests/helpers/index.ts
+++ b/tests/helpers/index.ts
@@ -246,9 +246,9 @@ export function mockNock(
  * ```
  */
 export function mockNockNetworkError(baseUrl: string, path: string, errorCode: string): nock.Scope {
-  return nock(baseUrl)
-    .get(path)
-    .replyWithError({ code: errorCode, message: `Network error: ${errorCode}` });
+  const error = new Error(`Network error: ${errorCode}`);
+  (error as NodeJS.ErrnoException).code = errorCode;
+  return nock(baseUrl).get(path).replyWithError(error);
 }
 
 /**


### PR DESCRIPTION
## Summary
This PR increases Jest coverage thresholds to 80% and fixes all failing tests caused by nock v14.x compatibility issues with @mswjs/interceptors.

## Changes Made

### Coverage Thresholds
- Updated `jest.config.js` to enforce 80% coverage for all metrics
- All thresholds exceeded:
  - **Statements:** 90.6% ✓ (10.6% above threshold)
  - **Branches:** 88.23% ✓ (8.23% above threshold)  
  - **Functions:** 96.77% ✓ (16.77% above threshold)
  - **Lines:** 90.85% ✓ (10.85% above threshold)

### Test Fixes
Fixed nock v14.x compatibility issues where `replyWithError` requires Error instances instead of plain objects:

- `tests/helpers/index.ts`: Updated `mockNockNetworkError` to create proper Error instances with error codes
- `tests/client/auth.test.ts`: Fixed network error test to use Error instance  
- `tests/client/retry.test.ts`: Fixed timeout error test to use Error instance

## Test Results
- **Before:** 167 passing, 11 failing
- **After:** All 178 tests passing ✓

## Technical Details
The failures were caused by nock v14.0.10 requiring Error instances when using `replyWithError`, but tests were passing plain objects like `{ code: 'ECONNREFUSED', message: '...' }`. This triggered "Reflect.has called on non-object" errors in the @mswjs/interceptors dependency.

**Solution:** Create Error instances and add the code property:
```typescript
const error = new Error('Network error: ECONNREFUSED');
(error as NodeJS.ErrnoException).code = 'ECONNREFUSED';
nock(baseUrl).get(path).replyWithError(error);
```

## Verification
- ✅ All tests passing (178/178)
- ✅ Coverage exceeds all 80% thresholds
- ✅ Linting passes
- ✅ Formatting passes
- ✅ Build succeeds

Fixes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)