### PR TITLE
fix: disable Husky hooks in CI to allow semantic-release commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,4 +53,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          HUSKY: 0
         run: npx semantic-release


### PR DESCRIPTION
## Summary
Fixes the semantic-release workflow failure by disabling Husky git hooks during CI execution.

## Problem
The semantic-release workflow was failing with:
```
✖   footer must have leading blank line [footer-leading-blank]
husky - commit-msg script failed (code 1)
```

Husky's commit-msg hook (commitlint) was running in CI and rejecting semantic-release's automated commit message because it didn't meet the `footer-leading-blank` rule.

## Solution
Add `HUSKY=0` environment variable to the semantic-release step in `.github/workflows/release.yml`. This disables all Husky git hooks during the CI release process.

## Changes
- `.github/workflows/release.yml`: Added `HUSKY: 0` to semantic-release step environment variables

## Impact
- ✅ Semantic-release can now commit and push release artifacts (CHANGELOG.md, package.json)
- ✅ Husky hooks still run locally for developer commits (maintains code quality)
- ✅ CI workflow can complete end-to-end automated releases
- ✅ NPM_TOKEN secret has been set and verified

## Testing
After merge, the release workflow will:
1. Run all validation (lint, format, build, tests)
2. Analyze commits and determine version bump (likely 0.2.0 based on feat commits)
3. Generate CHANGELOG.md
4. Commit changes without Husky interference
5. Publish to NPM as `@egulatee/pulumi-spring-cloud-config`
6. Create GitHub release with notes

Resolves #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)